### PR TITLE
chore: Add keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Keep Alive
         # If 55 days have passed then execute the action which makes an empty push
-        if: steps.commit_date.outputs.days_since_commit >= '55'
+        # if: steps.commit_date.outputs.days_since_commit >= '55'
         uses: pagopa/dx/.github/actions/keep-alive/@main

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,46 @@
+name: Keep Alive
+
+# This workflow is designed to keep the repository active.
+# GitHub automatically disables all actions with a cron trigger after 60 days of inactivity.
+# This action checks if there has been a commit in the last 55 days.
+# If a commit is found within this timeframe, the workflow does nothing,
+# however, if no commits have been made, it performs an empty push to keep the repository active.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Run at 00:00 every day
+  push:
+    branches:
+      - keep-alive
+
+jobs:
+  keep_alive:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
+
+      - name: Calculate days since last commit
+        id: commit_date
+        run: |
+          LAST_COMMIT_DATE=$(git log -1 --format=%ct)
+          echo "Last commit date: $LAST_COMMIT_DATE"
+
+          CURRENT_DATE=$(date +%s)
+          echo "Current date: $CURRENT_DATE"
+
+          # Calculate how many days have passed since the last commit
+          DIFFERENCE=$(( ($CURRENT_DATE - $LAST_COMMIT_DATE) / 86400 ))
+          echo "Days since last commit: $DIFFERENCE"
+
+          echo "days_since_commit=$DIFFERENCE" >> $GITHUB_ENV
+
+      - name: Keep Alive
+        # If 55 days have passed then execute the action which makes an empty push
+        if: steps.commit_date.outputs.days_since_commit >= '55'
+        uses: pagopa/dx/.github/actions/keep-alive/@main

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # Run at 00:00 every day
-  push:
-    branches:
-      - keep-alive
 
 jobs:
   keep_alive:

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -18,8 +18,10 @@ jobs:
   keep_alive:
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
+      contents: write
       actions: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
+        with:
+          ref: 'main'
 
       - name: Calculate days since last commit
         id: commit_date

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.7
-        with:
-          ref: 'main'
 
       - name: Calculate days since last commit
         id: commit_date


### PR DESCRIPTION
Add workflow to do not deactivate `schedule` trigger when there is no activity for 60 days or more

N.B.: a new PR to restore the commented `if` condition is needed

Closes #CES-819