### PR TITLE
chore: Restore filter to avoid empty commits when unnecessary by keep-alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -41,5 +41,5 @@ jobs:
 
       - name: Keep Alive
         # If 55 days have passed then execute the action which makes an empty push
-        # if: steps.commit_date.outputs.days_since_commit >= '55'
+        if: steps.commit_date.outputs.days_since_commit >= '55'
         uses: pagopa/dx/.github/actions/keep-alive/@main


### PR DESCRIPTION
Restore empty filters after tests

Closes #CES-819