### PR TITLE
fix: Replace non-existing team in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/engineering-cloud @pagopa/engineering-team-cloud-eng
+* @pagopa/engineering-cloud @pagopa/engineering-team-devex


### PR DESCRIPTION
Update the CODEOWNERS file to reflect the correct team responsible for the project. This change ensures proper ownership and accountability within the repository.

